### PR TITLE
Improvement: static decoder loading and hostname verify

### DIFF
--- a/enos-http-sdk/pom.xml
+++ b/enos-http-sdk/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.envisioniot</groupId>
         <artifactId>enos-iot-sdk-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/enos-http-sdk/pom.xml
+++ b/enos-http-sdk/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>enos-http</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
 
     <packaging>jar</packaging>
 
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.envisioniot</groupId>
             <artifactId>enos-core</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/enos-mqtt-sdk/pom.xml
+++ b/enos-mqtt-sdk/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.envisioniot</groupId>
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>enos-mqtt</artifactId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
 
     <packaging>jar</packaging>
 
@@ -19,25 +19,25 @@
     <url>https://github.com/EnvisionIot/enos-device-sdk-java</url>
 
     <description>
-        0.0.3-SNAPSHOT remove command DeleteDeviceCommand DisableDeviceCommand
+        0.0.3 remove command DeleteDeviceCommand DisableDeviceCommand
         use these command instead: SubDeviceDelete, SubDeviceDisable SubDeviceEnable commands
         remove RrpcCommand, the ServiceInvocationCommand handle the sync service as well
         add requests including : QueryDeviceTag,AttributeQuery,AttributeUpdate
-        0.0.4-SNAPSHOT rename some requests
+        0.0.4 rename some requests
         2.1.0 release
-        2.1.1-SNAPSHOT support dynamic activate(login by productSecret)
+        2.1.1 support dynamic activate(login by productSecret)
         support init by config file
-        2.1.2-SNAPSHOT support ota feature
-        2.1.2 release
+        2.1.2 support ota feature
         2.1.3 message integration
-        2.1.4-SNAPSHOT internal logic refactor, fix thread pool resource leak
-        2.1.5-SNAPSHOT support device name internationalization for device registering
-        2.1.6-SNAPSHOT fix potential hanging bug during re-connect in paho
-        2.1.7-SNAPSHOT batch login sub-device
+        2.1.4 internal logic refactor, fix thread pool resource leak
+        2.1.5 support device name internationalization for device registering
+        2.1.6 fix potential hanging bug during re-connect in paho
+        2.1.7 batch login sub-device
         2.1.8 support composite jks
-        2.2.0-SNAPSHOT seperate the common part (message parsing etc.) into independent project
-        2.2.1-SNAPSHOT add file check in mqtt request (file is not supported yet)
-        2.2.2-SNAPSHOT upgrade to paho mqtt 1.2.1 due to security check
+        2.2.0 seperate the common part (message parsing etc.) into independent project
+        2.2.1 add file check in mqtt request (file is not supported yet)
+        2.2.2 upgrade to paho mqtt 1.2.1 due to security check
+        2.2.3 solve decoder initialization defect in SpringBoot application, solve the problem of checking sans by default due to paho upgrade
     </description>
 
     <properties>
@@ -59,13 +59,26 @@
         <dependency>
             <groupId>com.envisioniot</groupId>
             <artifactId>enos-core</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
             <version>1.2.1</version>
+        </dependency>
+
+        <!-- Test lib -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
+            <version>2.0.0.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/enos-mqtt-sdk/pom.xml
+++ b/enos-mqtt-sdk/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.envisioniot</groupId>
         <artifactId>enos-iot-sdk-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/enos-mqtt-sdk/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/core/internals/DecoderRegistry.java
+++ b/enos-mqtt-sdk/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/core/internals/DecoderRegistry.java
@@ -1,11 +1,11 @@
 package com.envisioniot.enos.iot_mqtt_sdk.core.internals;
 
 import com.envisioniot.enos.iot_mqtt_sdk.core.msg.IMqttArrivedMessage;
-import com.envisioniot.enos.iot_mqtt_sdk.util.PackageScanUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -25,11 +25,56 @@ public class DecoderRegistry {
         // For uplink response can be dynamically loaded
         // Just need to statically load the encoding method of various Commands
         try {
-            for (Class<?> clss : PackageScanUtil.scan(DECODER_PACKAGE, IMqttArrivedMessage.class)) {
-                IMqttArrivedMessage decoder = (IMqttArrivedMessage) clss.newInstance();
-                decoderList.add(decoder);
-            }
-        } catch (Exception e) {
+            String[] classNames = new String[] {
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.downstream.tsl.MeasurepointSetCommand",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.downstream.tsl.ModelDownRawCommand",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.downstream.tsl.MeasurepointGetCommand",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.downstream.tsl.ServiceInvocationCommand",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.downstream.device.SubDeviceDisableCommand",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.downstream.device.SubDeviceEnableCommand",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.downstream.device.SubDeviceDeleteCommand",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.downstream.activate.DeviceActivateInfoCommand",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.downstream.ota.OtaUpgradeCommand",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.topo.TopoAddResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.topo.TopoDeleteResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.topo.TopoGetResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.tsl.AttributeDeleteResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.tsl.AttributeUpdateResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.tsl.AttributeQueryResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.tsl.EventPostResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.tsl.MeasurepointPostBatchResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.tsl.TslTemplateGetResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.tsl.MeasurepointPostResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.tsl.ModelUpRawResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.integration.IntEventPostResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.integration.IntAttributePostResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.integration.IntMeasurepointPostResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.integration.IntModelUpRawResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.resume.MeasurepointResumeBatchResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.resume.MeasurepointResumeResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.status.SubDeviceLoginBatchResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.status.SubDeviceLogoutResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.status.SubDeviceLoginResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.register.DeviceRegisterResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.ota.OtaProgressReportResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.ota.OtaGetVersionResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.ota.OtaVersionReportResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.tag.TagDeleteResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.tag.TagUpdateResponse",
+                    "com.envisioniot.enos.iot_mqtt_sdk.message.upstream.tag.TagQueryResponse"
+            };
+            Arrays.stream(classNames).forEach(n -> {
+                IMqttArrivedMessage decoder;
+                try
+                {
+                    decoder = (IMqttArrivedMessage) Class.forName(n).newInstance();
+                    decoderList.add(decoder);
+                } catch (Exception e)
+                {
+                    logger.error("register downstream command decoder failed ", e);
+                }
+            });
+        } catch (Throwable e) {
             logger.error("register downstream command decoder failed ", e);
         }
     }

--- a/enos-mqtt-sdk/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/core/internals/DefaultProcessor.java
+++ b/enos-mqtt-sdk/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/core/internals/DefaultProcessor.java
@@ -121,7 +121,7 @@ public class DefaultProcessor implements MqttCallback, MqttCallbackExtended {
                     } catch (Exception e) {
                         logger.error("handle the arrived msg err , may because of registered arrived msg callback ,", e);
                         try {
-                            BaseMqttReply reply = buildMqttReply((BaseMqttCommand) msg, pathList,
+                            BaseMqttReply reply = buildMqttReply((BaseMqttCommand<?>) msg, pathList,
                                     ResponseCode.COMMAND_HANDLER_EXECUTION_FAILED,
                                     String.format("command handler execution failed, %s", e.getMessage()));
                             connection.fastPublish(reply);
@@ -131,7 +131,7 @@ public class DefaultProcessor implements MqttCallback, MqttCallbackExtended {
                     }
                 });
             } else if (msg instanceof BaseMqttCommand) {
-                handleCommandWithNoHandler((BaseMqttCommand) msg, pathList);
+                handleCommandWithNoHandler((BaseMqttCommand<?>) msg, pathList);
             }
         } catch (Exception e) {
             logger.error("UGLY INTERNAL ERR!! , processing the arrived  msg err , topic {}  uncaught exception : ",
@@ -140,7 +140,7 @@ public class DefaultProcessor implements MqttCallback, MqttCallbackExtended {
     }
 
 
-    private void handleCommandWithNoHandler(BaseMqttCommand msg, List<String> pathList) {
+    private void handleCommandWithNoHandler(BaseMqttCommand<?> msg, List<String> pathList) {
         connection.getExecutorFactory().getPublishExecutor().execute(() -> {
             try {
                 BaseMqttReply reply = buildMqttReply(msg, pathList,
@@ -177,7 +177,7 @@ public class DefaultProcessor implements MqttCallback, MqttCallbackExtended {
         }
     }
 
-    private BaseMqttReply buildMqttReply(BaseMqttCommand msg, List<String> pathList, int code, String message) throws IllegalAccessException, InstantiationException {
+    private BaseMqttReply buildMqttReply(BaseMqttCommand<?> msg, List<String> pathList, int code, String message) throws IllegalAccessException, InstantiationException {
         BaseMqttReply reply = (BaseMqttReply) msg.getAnswerType().newInstance();
         reply.setMessageId(msg.getMessageId());
         reply.setProductKey(msg.getProductKey());
@@ -209,6 +209,7 @@ public class DefaultProcessor implements MqttCallback, MqttCallbackExtended {
         return connectCallback;
     }
 
+    @SuppressWarnings("unlikely-arg-type")
     public void removeArrivedMsgHandler(String topic) {
         arrivedMsgHandlerMap.remove(topic);
     }

--- a/enos-mqtt-sdk/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/core/internals/MqttConnection.java
+++ b/enos-mqtt-sdk/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/core/internals/MqttConnection.java
@@ -451,7 +451,7 @@ public class MqttConnection {
 
             // Also populate request version for IMqttRequest
             if (delivered instanceof IMqttRequest) {
-                IMqttRequest request = (IMqttRequest) delivered;
+                IMqttRequest<?> request = (IMqttRequest<?>) delivered;
                 if (StringUtil.isEmpty(request.getVersion())) {
                     request.setVersion(BaseProfile.VERSION);
                 }
@@ -662,7 +662,7 @@ public class MqttConnection {
 
             IResponseCallback<M> wrapped = callback;
             if (Objects.nonNull(wrapped)) {
-                final ScheduledFuture future = executorFactory.getTimeoutScheduler().schedule(
+                final ScheduledFuture<?> future = executorFactory.getTimeoutScheduler().schedule(
                         () -> {
                             logger.error("callback task timeout {}", answerTopicId);
                             getProcessor().deregisterResponseToken(answerTopicId);

--- a/enos-mqtt-sdk/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/core/profile/BaseProfile.java
+++ b/enos-mqtt-sdk/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/core/profile/BaseProfile.java
@@ -100,7 +100,7 @@ public abstract class BaseProfile {
         connectOptions.setAutomaticReconnect(this.config.getAutoReconnect());
         connectOptions.setConnectionTimeout(this.config.getConnectionTimeout());
         connectOptions.setMaxInflight(this.config.getMaxInFlight());
-
+        connectOptions.setHttpsHostnameVerificationEnabled(this.config.isHostnameVerifyEnabled());
         if (config.getSslSecured()) {
             if (this.sslContext == null) {
                 try {
@@ -227,6 +227,11 @@ public abstract class BaseProfile {
 
     public BaseProfile setServerUrl(String serverUrl) {
         this.config.setServerUrl(serverUrl);
+        return this;
+    }
+
+    public BaseProfile setHostnameVerifyEnabled(boolean hostnameVerifyEnabled) {
+        this.config.setHostnameVerifyEnabled(hostnameVerifyEnabled);
         return this;
     }
 

--- a/enos-mqtt-sdk/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/core/profile/Config.java
+++ b/enos-mqtt-sdk/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/core/profile/Config.java
@@ -8,43 +8,45 @@ import com.google.common.io.Files;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
+ * {
+ * //store properties by mqtt sdk
+ * //Thu Jan 10 14:53:58 CST 2019
+ * //serverUrl=tcp://alpha-k8s-cn4.eniot.io:11883
+ * //"assetId":"FgEWZ6Fz"
+ * "serverUrl":"ssl://10.27.21.6:18883",
+ * "productKey":"fKInRgVP",
+ * "productSecret":"c3PW03srd6c,
+ * "deviceKey":"zscai_test_activate",
+ * "deviceSecret":"DrihKncQARUwVXUvRH6k",
+ * "operationTimeout":60,
+ * "sslPassword":"",
+ * "maxInFlight":"10000",
+ * "sslAlgorithm":"SunX509",
+ * "connectionTimeout":30,
+ * "sslJksPath":"",
+ * "autoReconnect":true,
+ * "keepAlive":60,
+ * "subDevices":[
+ * {
+ * "productKey":"subProduct",
+ * "deviceKey":"subdevice",
+ * "deviceSecret":"xxx",
+ * "product":"secret"
+ * },
+ * {
+ * "productKey":"subProduct",
+ * "deviceKey":"subdevice",
+ * "deviceSecret":"xxx",
+ * "product":"secret"
+ * }
+ * ]
+ * }
  *
- {
- //store properties by mqtt sdk
- //Thu Jan 10 14:53:58 CST 2019
- //serverUrl=tcp://alpha-k8s-cn4.eniot.io:11883
- //"assetId":"FgEWZ6Fz"
- "serverUrl":"ssl://10.27.21.6:18883",
- "productKey":"fKInRgVP",
- "productSecret":"c3PW03srd6c,
- "deviceKey":"zscai_test_activate",
- "deviceSecret":"DrihKncQARUwVXUvRH6k",
- "operationTimeout":60,
- "sslPassword":"",
- "maxInFlight":"10000",
- "sslAlgorithm":"SunX509",
- "connectionTimeout":30,
- "sslJksPath":"",
- "autoReconnect":true,
- "keepAlive":60,
- "subDevices":[
- {
- "productKey":"subProduct",
- "deviceKey":"subdevice",
- "deviceSecret":"xxx",
- "product":"secret"
- },
- {
- "productKey":"subProduct",
- "deviceKey":"subdevice",
- "deviceSecret":"xxx",
- "product":"secret"
- }
- ]
- }
  * @author zhensheng.cai
  * @date 2019/1/14.
  */
@@ -70,6 +72,7 @@ public class Config {
     private String sslPassword = "";
     private String sslAlgorithm = "SunX509";
     private String sslJksPath = "";
+    private boolean hostnameVerifyEnabled = false;
 
     // Use String for easy serialization/de-serialization
     private String signMethodName = SignUtil.DEFAULT_SIGN_METHOD.getName();
@@ -232,6 +235,15 @@ public class Config {
 
     public Config setSignMethod(SignMethod signMethod) {
         this.signMethodName = signMethod.getName();
+        return this;
+    }
+
+    public Boolean isHostnameVerifyEnabled() {
+        return this.hostnameVerifyEnabled;
+    }
+
+    public Config setHostnameVerifyEnabled(boolean hostnameVerifyEnabled) {
+        this.hostnameVerifyEnabled = hostnameVerifyEnabled;
         return this;
     }
 

--- a/enos-mqtt-sdk/src/test/java/com/envisioniot/enos/iot_mqtt_sdk/DecoderRegistryTest.java
+++ b/enos-mqtt-sdk/src/test/java/com/envisioniot/enos/iot_mqtt_sdk/DecoderRegistryTest.java
@@ -1,0 +1,40 @@
+package com.envisioniot.enos.iot_mqtt_sdk;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import com.envisioniot.enos.iot_mqtt_sdk.core.internals.DecoderRegistry;
+import com.envisioniot.enos.iot_mqtt_sdk.core.msg.IMqttArrivedMessage;
+import com.envisioniot.enos.iot_mqtt_sdk.util.PackageScanUtil;
+
+public class DecoderRegistryTest
+{
+
+    /**
+     * check the integrity of decoder registry, all decoders are specified in registry 
+     * initialization
+     */
+    @Test
+    public void testIntegrity()
+    {
+        try
+        {
+            List<Class<?>> decoderClazzes = PackageScanUtil.scan(DecoderRegistry.DECODER_PACKAGE, IMqttArrivedMessage.class);
+
+            assertThat(DecoderRegistry.getDecoderList(), containsInAnyOrder(
+                    decoderClazzes.stream()
+                    .map(cls -> instanceOf(cls))
+                    .collect(Collectors.toList())));
+        } catch (Exception e)
+        {
+            fail("exception in package scan");
+        }
+    }
+}

--- a/enos-sdk-core/pom.xml
+++ b/enos-sdk-core/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.envisioniot</groupId>
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>enos-core</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
 
     <packaging>jar</packaging>
 

--- a/enos-sdk-core/pom.xml
+++ b/enos-sdk-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.envisioniot</groupId>
         <artifactId>enos-iot-sdk-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/enos-sdk-core/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/message/AckMessageBody.java
+++ b/enos-sdk-core/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/message/AckMessageBody.java
@@ -4,7 +4,6 @@ import com.envisioniot.enos.iot_mqtt_sdk.message.upstream.ResponseCode;
 import com.envisioniot.enos.iot_mqtt_sdk.util.ExactValue;
 import com.envisioniot.enos.iot_mqtt_sdk.util.GsonUtil;
 
-import com.envisioniot.enos.iot_mqtt_sdk.message.AnswerableMessageBody;
 import com.envisioniot.enos.iot_mqtt_sdk.message.downstream.BaseMqttReply;
 import com.envisioniot.enos.iot_mqtt_sdk.message.upstream.BaseMqttResponse;
 
@@ -78,7 +77,7 @@ public class AckMessageBody extends BaseMessageBody implements Serializable {
 
     @Override
     public String toString() {
-        return "AckMessageBody{" + "id='" + id + '\'' + ", code=" + code + ", data=" + data + ", message='" + message
+        return this.getClass().getSimpleName() + "{" + "id='" + id + '\'' + ", code=" + code + ", data=" + data + ", message='" + message
                 + '\'' + '}';
     }
 }

--- a/enos-sdk-core/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/message/AnswerableMessageBody.java
+++ b/enos-sdk-core/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/message/AnswerableMessageBody.java
@@ -85,7 +85,7 @@ public class AnswerableMessageBody extends BaseMessageBody implements Serializab
 
     @Override
     public String toString() {
-        return "AnswerableMessageBody{" + "id='" + id + '\'' + ", method='" + method + '\'' + ", version='" + version
+        return this.getClass().getSimpleName() + "{" + "id='" + id + '\'' + ", method='" + method + '\'' + ", version='" + version
                 + '\'' + ", params=" + params + '}';
     }
 }

--- a/enos-sdk-core/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/message/upstream/status/SubDeviceLoginBatchResponse.java
+++ b/enos-sdk-core/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/message/upstream/status/SubDeviceLoginBatchResponse.java
@@ -20,8 +20,6 @@ import java.util.regex.Pattern;
 public class SubDeviceLoginBatchResponse extends BaseMqttResponse {
     private static final long serialVersionUID = -1L;
 
-    private static final int HORRIBLE_ERROR_CODE = 500;
-
     private static Pattern pattern = Pattern.compile(ArrivedTopicPattern.SUB_DEVICE_LOGIN_BATCH_REPLY);
 
     private List<LoginSuccessResult> successResults;

--- a/enos-sdk-core/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/util/PackageScanUtil.java
+++ b/enos-sdk-core/src/main/java/com/envisioniot/enos/iot_mqtt_sdk/util/PackageScanUtil.java
@@ -1,192 +1,63 @@
 package com.envisioniot.enos.iot_mqtt_sdk.util;
 
-import com.envisioniot.enos.iot_mqtt_sdk.core.msg.IMqttArrivedMessage;
 
-import java.io.File;
-import java.io.UnsupportedEncodingException;
+import java.io.IOException;
 import java.lang.reflect.Modifier;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.Enumeration;
 import java.util.List;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.envisioniot.enos.iot_mqtt_sdk.core.msg.IMqttArrivedMessage;
+import com.google.common.reflect.ClassPath;
 
 /**
- * @author zhensheng.cai
- * @date 2018/7/31.
+ * This is a helper class to scan decoder package.
+ * However it's not suitable for using in some production application,
+ * e.g. all-in-one JAR built by a SpringBoot Application
+ * @author shenjieyuan
  */
 public class PackageScanUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(PackageScanUtil.class);
+    
     public static void main(String[] args) throws Exception {
         String packageName = "com.envisioniot.enos.iot_mqtt_sdk";
-        scan(packageName, IMqttArrivedMessage.class);
-    }
-
-    public static List<Class<?>> scan(String pkg, Class<?> filter) throws ClassNotFoundException {
-        List<Class<?>> ret = new ArrayList<>();
-        List<String> classNames = getClassName(pkg, true);
-        if (classNames != null) {
-            for (String className : classNames) {
-                Class<?> cls = Class.forName(className);
-
-                if (Modifier.isAbstract(cls.getModifiers())) {
-                    continue;
-                }
-
-                if (filter.isAssignableFrom(cls)) {
-                    ret.add(cls);
-                }
-            }
-        }
-
-        return ret;
+        System.out.println(scan(packageName, IMqttArrivedMessage.class)
+                .stream().map(c -> '"' + c.getName() + '"')
+                .collect(Collectors.toList()));
     }
 
     /**
-     * Get all classes under a package (including all child-packages of the package)
-     *
-     * @param packageName 
-     * @return The full name of the class
+     * Use Guava ClassPath to search for classes.
+     * !! TEST ONLY !!
+     * @param pkg
+     * @param filter
+     * @return
+     * @throws ClassNotFoundException
+     * @throws IOException
      */
-    public static List<String> getClassName(String packageName) {
-        return getClassName(packageName, true);
-    }
-
-    /**
-     * Get all classes in a package
-     *
-     * @param packageName  
-     * @param childPackage Whether to traverse child-packages
-     * @return The full name of the class
-     */
-    public static List<String> getClassName(String packageName, boolean childPackage) {
-        List<String> fileNames = null;
+    public static List<Class<?>> scan(String pkg, Class<?> filter) throws ClassNotFoundException, IOException {
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        String packagePath = packageName.replace(".", "/");
-        URL url = loader.getResource(packagePath);
-        if (url != null) {
-            String urlPath;
-            try {
-                urlPath = URLDecoder.decode(url.getPath(), "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                return fileNames;
+        return ClassPath.from(loader).getTopLevelClassesRecursive(pkg)
+        .stream()
+        .map(info -> {
+            try
+            {
+                return Class.forName(info.getName());
+            } catch (ClassNotFoundException e)
+            {
+                logger.error("", e);
+                return null;
             }
-            String type = url.getProtocol();
-            if (type.equals("file")) {
-                fileNames = getClassNameByFile(urlPath, null, childPackage);
-            } else if (type.equals("jar")) {
-                fileNames = getClassNameByJar(urlPath, childPackage);
-            }
-        } else {
-            fileNames = getClassNameByJars(((URLClassLoader) loader).getURLs(), packagePath, childPackage);
-        }
-        return fileNames;
+        })
+        .filter(clazz -> 
+        {
+            return clazz != null &&
+                   !Modifier.isAbstract(clazz.getModifiers()) &&
+                   filter.isAssignableFrom(clazz);
+        })
+        .collect(Collectors.toList());
     }
-
-    /**
-     * Get all classes in a package from the project file
-     *
-     * @param filePath     
-     * @param className    
-     * @param childPackage Whether to traverse child packages
-     * @return The full name of the class
-     */
-    private static List<String> getClassNameByFile(String filePath, List<String> className, boolean childPackage) {
-        List<String> myClassName = new ArrayList<String>();
-        File file = new File(filePath);
-        File[] childFiles = file.listFiles();
-        for (File childFile : childFiles) {
-            if (childFile.isDirectory()) {
-                if (childPackage) {
-                    myClassName.addAll(getClassNameByFile(childFile.getPath(), myClassName, childPackage));
-                }
-            } else {
-                String childFilePath = childFile.getPath();
-                if (childFilePath.endsWith(".class")) {
-                    childFilePath = childFilePath.substring(childFilePath.indexOf(File.separator + "classes") + 9, childFilePath.lastIndexOf("."));
-                    childFilePath = childFilePath.replace(File.separator, ".");
-                    myClassName.add(childFilePath);
-                }
-            }
-        }
-
-        return myClassName;
-    }
-
-    /**
-     * Get all classes in a package from jar
-     *
-     * @param jarPath      jar file path
-     * @param childPackage whether to traverse child-packages
-     * @return The full name of a class
-     */
-    private static List<String> getClassNameByJar(String jarPath, boolean childPackage) {
-        List<String> myClassName = new ArrayList<String>();
-        String[] jarInfo = jarPath.split("!");
-        String jarFilePath = jarInfo[0].substring(jarInfo[0].indexOf("/"));
-        String packagePath = jarInfo[1].substring(1);
-        try {
-            JarFile jarFile = new JarFile(jarFilePath);
-            try {
-                Enumeration<JarEntry> entrys = jarFile.entries();
-                while (entrys.hasMoreElements()) {
-                    JarEntry jarEntry = entrys.nextElement();
-                    String entryName = jarEntry.getName();
-                    if (entryName.endsWith(".class")) {
-                        if (childPackage) {
-                            if (entryName.startsWith(packagePath)) {
-                                entryName = entryName.replace("/", ".").substring(0, entryName.lastIndexOf("."));
-                                myClassName.add(entryName);
-                            }
-                        } else {
-                            int index = entryName.lastIndexOf("/");
-                            String myPackagePath;
-                            if (index != -1) {
-                                myPackagePath = entryName.substring(0, index);
-                            } else {
-                                myPackagePath = entryName;
-                            }
-                            if (myPackagePath.equals(packagePath)) {
-                                entryName = entryName.replace("/", ".").substring(0, entryName.lastIndexOf("."));
-                                myClassName.add(entryName);
-                            }
-                        }
-                    }
-                }
-            } finally {
-                jarFile.close();
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return myClassName;
-    }
-
-    /**
-     * Search the package from all jars and get all the classes under the package
-     *
-     * @param urls         URLs
-     * @param packagePath  
-     * @param childPackage whether to traverse child packages
-     * @return The full name of a class
-     */
-    private static List<String> getClassNameByJars(URL[] urls, String packagePath, boolean childPackage) {
-        List<String> myClassName = new ArrayList<String>();
-        if (urls != null) {
-            for (int i = 0; i < urls.length; i++) {
-                URL url = urls[i];
-                String urlPath = url.getPath();
-                // No need to search the classes folder
-                if (urlPath.endsWith("classes/")) {
-                    continue;
-                }
-                String jarPath = urlPath + "!/" + packagePath;
-                myClassName.addAll(getClassNameByJar(jarPath, childPackage));
-            }
-        }
-        return myClassName;
-    }
-
 }

--- a/enos-sdk-sample/pom.xml
+++ b/enos-sdk-sample/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.envisioniot</groupId>
@@ -39,12 +39,12 @@
         <dependency>
             <groupId>com.envisioniot</groupId>
             <artifactId>enos-mqtt</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.3</version>
         </dependency>
         <dependency>
             <groupId>com.envisioniot</groupId>
             <artifactId>enos-http</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -66,6 +66,22 @@
     </modules>
 
     <profiles>
+        <profile>
+            <id>envisionrepo</id>
+            <distributionManagement>
+                <repository>
+                    <id>envision.repo</id>
+                    <name>envision internal repository for released artifacts</name>
+                    <url>http://nexus.envisioncn.com/content/repositories/releases</url>
+                </repository>
+                <snapshotRepository>
+                    <id>envision.repo.snapshots</id>
+                    <name>envision internal repository for snapshots artifacts</name>
+                    <url>http://nexus.envisioncn.com/content/repositories/snapshots</url>
+                </snapshotRepository>
+            </distributionManagement>
+        </profile>
+
         <profile>
             <id>release</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.envisioniot</groupId>
     <artifactId>enos-iot-sdk-parent</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <packaging>pom</packaging>
 
     <name>EnOS IoT SDK</name>
@@ -130,17 +130,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.3</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>oss</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Two improvements are contained:

1. Use static loading to decoders in MQTT, to ensure enos-mqtt working in all-in-one JAR application.
2. By default, disable hostname verification, to ensure bi-directional authentication working in some JDK versions (1.8u51 - 1.8u60).